### PR TITLE
The stream needs to be drained before waiting for the exit.

### DIFF
--- a/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/Docker.java
@@ -74,14 +74,15 @@ public class Docker {
     public boolean isContainerRunning(String container) throws IOException, InterruptedException {
         ProcessBuilder pBuilder = cmd("ps").add("-q", "--filter", "\"id=" + container + '"').build();
         Process psProcess = pBuilder.start();
-        psProcess.waitFor();
-        if (psProcess.exitValue() == 0) {
-            String psOutput = IOUtils.toString(psProcess.getInputStream());
-            if (psOutput.contains(container)) {
-                return true;
-            }
-        }
 
+        String psOutput = IOUtils.toString(psProcess.getInputStream());
+        int pExit = psProcess.waitFor();
+        if (pExit == 0) {
+            return psOutput.contains(container);
+        }
+        // docker command errored - and it does not do this if there is no match.
+        System.err.println("docker ps failed with code: " + pExit + 
+                          (psOutput != null ? " and output: " + psOutput : " and provided no output"));
         return false;
     }
 

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -123,7 +123,8 @@ public class DockerImage {
         String output = IOUtils.toString(p.getInputStream());
 
         if (p.waitFor() != 0) {
-            throw new IOException("docker died unexpectedly: " + docker + "\n" + output);
+            throw new IOException("docker died unexpectedly with return code " + p.exitValue() + 
+                                   " : " + docker + "\n" + output);
         }
 
         if (output != null && output.length() != 0) {

--- a/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
+++ b/src/main/java/org/jenkinsci/test/acceptance/docker/DockerImage.java
@@ -119,11 +119,10 @@ public class DockerImage {
     }
 
     private String waitForCid(CommandBuilder docker, Process p) throws InterruptedException, IOException {
-        p.waitFor();
 
         String output = IOUtils.toString(p.getInputStream());
 
-        if (p.exitValue() != 0) {
+        if (p.waitFor() != 0) {
             throw new IOException("docker died unexpectedly: " + docker + "\n" + output);
         }
 


### PR DESCRIPTION
If the stream is not drained then the process can actually block wrting
output, and in this case the process will never exit.

https://www.securecoding.cert.org/confluence/display/java/FIO07-J.+Do+not+let+external+processes+block+on+IO+buffers
